### PR TITLE
fix(drag-n-drop): ignore consecutive touchmove events on drag item on multitouch

### DIFF
--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -156,6 +156,39 @@ describe('DragDropRegistry', () => {
     pointerMoveSubscription.unsubscribe();
   });
 
+  it('should not emit pointer events on item when drag is over (mutli touch)', () => {
+    const firstItem = testComponent.dragItems.first;
+
+    // First finger down
+    registry.startDragging(firstItem, createTouchEvent('touchstart') as TouchEvent);
+    // Second finger down
+    registry.startDragging(firstItem, createTouchEvent('touchstart') as TouchEvent);
+    // First finger up
+    registry.stopDragging(firstItem);
+
+    // Ensure drag is over - registry is empty
+    expect(registry.isDragging(firstItem)).toBe(false);
+
+    const pointerUpSpy = jasmine.createSpy('pointerUp spy');
+    const pointerMoveSpy = jasmine.createSpy('pointerMove spy');
+
+    const pointerUpSubscription = registry.pointerUp.subscribe(pointerUpSpy);
+    const pointerMoveSubscription = registry.pointerMove.subscribe(pointerMoveSpy);
+
+    // Second finger keeps moving
+    dispatchTouchEvent(document, 'touchmove');
+    expect(pointerMoveSpy).not.toHaveBeenCalled();
+
+    // Second finger up
+    dispatchTouchEvent(document, 'touchend');
+    expect(pointerUpSpy).not.toHaveBeenCalled();
+
+    pointerUpSubscription.unsubscribe();
+    pointerMoveSubscription.unsubscribe();
+
+    registry.ngOnDestroy();
+  });
+
   it('should not throw when trying to register the same container again', () => {
     expect(() => registry.registerDropContainer(testComponent.dropInstances.first)).not.toThrow();
   });

--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -112,6 +112,10 @@ export class DragDropRegistry<I, C extends {id: string}> implements OnDestroy {
    * @param event Event that initiated the dragging.
    */
   startDragging(drag: I, event: TouchEvent | MouseEvent) {
+    if (this._activeDragInstances.has(drag)) {
+      return;
+    }
+
     this._activeDragInstances.add(drag);
 
     if (this._activeDragInstances.size === 1) {


### PR DESCRIPTION
Bumped into an inconsistent behaviour on multitouch. Currently the DragDropRegistry is designed atop of Set, and assumes there could be only one pointer active on item. Which is not true for multitouch devices.  

So there’re two ways to fix it:
1. Teach DragDropRegistry to respect multiple simultaneous pointers on one item.
2. Stick to Set as designed initially, respect only the first pointer on item, and properly ignore all consecutive pointers.

The first way looks much more promising, but requires much more effort and requires attention of core team, I suppose. The second one is not that flexible, but is still more consistent than the current implementation. So this commit implements the second way.